### PR TITLE
add discord_perms as a dependency

### DIFF
--- a/rolechat/__resource.lua
+++ b/rolechat/__resource.lua
@@ -1,3 +1,5 @@
+dependency 'discord_perms'
+
 server_script {
   "server.lua",
   "config.lua"


### PR DESCRIPTION
This will prevent any errors including `no export IsRolePresent in resource discord_perms` - this is good practice and prevents users from coming to you with these errors.